### PR TITLE
Pv/add explicit timeout to searches

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ Options:
   want to run a quicker test with a few queries rather than the thousands in each of the features tests
 - **--num-random** - The number of random queries to run.
 - **--verbosity** - DEBUG, INFO, WARNING, ERROR, or CRITICAL to set the level of logging that will be in the output
-
+- **--timeout** - Amount of time (in seconds) to run searches before considering them to have timed out
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -106,8 +106,9 @@ Options:
   collection queries. Otherwise, if there are
   large numbers of results for these queries, it may take a very long to paginate through them, and this doesn't
   necessarily reflect something a user will do in practice. This defaults to 10000.
-- **--features** - Only query this number of features from the feature collection inputs. This is useful if you just
+- **--num-features** - Only query this number of features from the feature collection inputs. This is useful if you just
   want to run a quicker test with a few queries rather than the thousands in each of the features tests
+- **--num-random** - The number of random queries to run.
 - **--verbosity** - DEBUG, INFO, WARNING, ERROR, or CRITICAL to set the level of logging that will be in the output
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -317,7 +317,7 @@ python-dateutil = ">=2.4"
 
 [[package]]
 name = "filelock"
-version = "3.6.0"
+version = "3.7.0"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
@@ -703,6 +703,21 @@ description = "C parser in Python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pydantic"
+version = "1.9.0"
+description = "Data validation and settings management using python 3.6 type hinting"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydocstyle"
@@ -1203,7 +1218,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "608fb61b9c37190a138112980d0671221cf6888676741f83a22a523bd35f55d7"
+content-hash = "e3c911424c5aeb7a61adcfd9c3fc3494511a30480aba9dfe93a311ae47eacfec"
 
 [metadata.files]
 aiodns = [
@@ -1584,8 +1599,8 @@ faker = [
     {file = "Faker-13.11.1.tar.gz", hash = "sha256:cad1f69d72a68878cd67855140b6fe3e44c11628971cd838595d289c98bc45de"},
 ]
 filelock = [
-    {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
-    {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
+    {file = "filelock-3.7.0-py3-none-any.whl", hash = "sha256:c7b5fdb219b398a5b28c8e4c1893ef5f98ece6a38c6ab2c22e26ec161556fed6"},
+    {file = "filelock-3.7.0.tar.gz", hash = "sha256:b795f1b42a61bbf8ec7113c341dad679d772567b936fbd1bf43c9a238e673e20"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
@@ -1927,6 +1942,43 @@ pycodestyle = [
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+pydantic = [
+    {file = "pydantic-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cb23bcc093697cdea2708baae4f9ba0e972960a835af22560f6ae4e7e47d33f5"},
+    {file = "pydantic-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1d5278bd9f0eee04a44c712982343103bba63507480bfd2fc2790fa70cd64cf4"},
+    {file = "pydantic-1.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab624700dc145aa809e6f3ec93fb8e7d0f99d9023b713f6a953637429b437d37"},
+    {file = "pydantic-1.9.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c8d7da6f1c1049eefb718d43d99ad73100c958a5367d30b9321b092771e96c25"},
+    {file = "pydantic-1.9.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3c3b035103bd4e2e4a28da9da7ef2fa47b00ee4a9cf4f1a735214c1bcd05e0f6"},
+    {file = "pydantic-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3011b975c973819883842c5ab925a4e4298dffccf7782c55ec3580ed17dc464c"},
+    {file = "pydantic-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:086254884d10d3ba16da0588604ffdc5aab3f7f09557b998373e885c690dd398"},
+    {file = "pydantic-1.9.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0fe476769acaa7fcddd17cadd172b156b53546ec3614a4d880e5d29ea5fbce65"},
+    {file = "pydantic-1.9.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8e9dcf1ac499679aceedac7e7ca6d8641f0193c591a2d090282aaf8e9445a46"},
+    {file = "pydantic-1.9.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1e4c28f30e767fd07f2ddc6f74f41f034d1dd6bc526cd59e63a82fe8bb9ef4c"},
+    {file = "pydantic-1.9.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:c86229333cabaaa8c51cf971496f10318c4734cf7b641f08af0a6fbf17ca3054"},
+    {file = "pydantic-1.9.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:c0727bda6e38144d464daec31dff936a82917f431d9c39c39c60a26567eae3ed"},
+    {file = "pydantic-1.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:dee5ef83a76ac31ab0c78c10bd7d5437bfdb6358c95b91f1ba7ff7b76f9996a1"},
+    {file = "pydantic-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9c9bdb3af48e242838f9f6e6127de9be7063aad17b32215ccc36a09c5cf1070"},
+    {file = "pydantic-1.9.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ee7e3209db1e468341ef41fe263eb655f67f5c5a76c924044314e139a1103a2"},
+    {file = "pydantic-1.9.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b6037175234850ffd094ca77bf60fb54b08b5b22bc85865331dd3bda7a02fa1"},
+    {file = "pydantic-1.9.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b2571db88c636d862b35090ccf92bf24004393f85c8870a37f42d9f23d13e032"},
+    {file = "pydantic-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8b5ac0f1c83d31b324e57a273da59197c83d1bb18171e512908fe5dc7278a1d6"},
+    {file = "pydantic-1.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:bbbc94d0c94dd80b3340fc4f04fd4d701f4b038ebad72c39693c794fd3bc2d9d"},
+    {file = "pydantic-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e0896200b6a40197405af18828da49f067c2fa1f821491bc8f5bde241ef3f7d7"},
+    {file = "pydantic-1.9.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7bdfdadb5994b44bd5579cfa7c9b0e1b0e540c952d56f627eb227851cda9db77"},
+    {file = "pydantic-1.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:574936363cd4b9eed8acdd6b80d0143162f2eb654d96cb3a8ee91d3e64bf4cf9"},
+    {file = "pydantic-1.9.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c556695b699f648c58373b542534308922c46a1cda06ea47bc9ca45ef5b39ae6"},
+    {file = "pydantic-1.9.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:f947352c3434e8b937e3aa8f96f47bdfe6d92779e44bb3f41e4c213ba6a32145"},
+    {file = "pydantic-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5e48ef4a8b8c066c4a31409d91d7ca372a774d0212da2787c0d32f8045b1e034"},
+    {file = "pydantic-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:96f240bce182ca7fe045c76bcebfa0b0534a1bf402ed05914a6f1dadff91877f"},
+    {file = "pydantic-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:815ddebb2792efd4bba5488bc8fde09c29e8ca3227d27cf1c6990fc830fd292b"},
+    {file = "pydantic-1.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6c5b77947b9e85a54848343928b597b4f74fc364b70926b3c4441ff52620640c"},
+    {file = "pydantic-1.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c68c3bc88dbda2a6805e9a142ce84782d3930f8fdd9655430d8576315ad97ce"},
+    {file = "pydantic-1.9.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a79330f8571faf71bf93667d3ee054609816f10a259a109a0738dac983b23c3"},
+    {file = "pydantic-1.9.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f5a64b64ddf4c99fe201ac2724daada8595ada0d102ab96d019c1555c2d6441d"},
+    {file = "pydantic-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a733965f1a2b4090a5238d40d983dcd78f3ecea221c7af1497b845a9709c1721"},
+    {file = "pydantic-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cc6a4cb8a118ffec2ca5fcb47afbacb4f16d0ab8b7350ddea5e8ef7bcc53a16"},
+    {file = "pydantic-1.9.0-py3-none-any.whl", hash = "sha256:085ca1de245782e9b46cefcf99deecc67d418737a1fd3f6a4f511344b613a5b3"},
+    {file = "pydantic-1.9.0.tar.gz", hash = "sha256:742645059757a56ecd886faf4ed2441b9c0cd406079c2b4bee51bcc3fbcd510a"},
 ]
 pydocstyle = [
     {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -173,11 +173,11 @@ python-versions = "*"
 
 [[package]]
 name = "certifi"
-version = "2021.10.8"
+version = "2022.5.18.1"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "cffi"
@@ -458,7 +458,7 @@ gitdb = ">=4.0.1,<5"
 
 [[package]]
 name = "identify"
-version = "2.5.0"
+version = "2.5.1"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -703,21 +703,6 @@ description = "C parser in Python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
-name = "pydantic"
-version = "1.9.0"
-description = "Data validation and settings management using python 3.6 type hinting"
-category = "main"
-optional = false
-python-versions = ">=3.6.1"
-
-[package.dependencies]
-typing-extensions = ">=3.7.4.3"
-
-[package.extras]
-dotenv = ["python-dotenv (>=0.10.4)"]
-email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydocstyle"
@@ -1218,7 +1203,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "e3c911424c5aeb7a61adcfd9c3fc3494511a30480aba9dfe93a311ae47eacfec"
+content-hash = "608fb61b9c37190a138112980d0671221cf6888676741f83a22a523bd35f55d7"
 
 [metadata.files]
 aiodns = [
@@ -1456,8 +1441,8 @@ cchardet = [
     {file = "cchardet-2.1.7.tar.gz", hash = "sha256:c428b6336545053c2589f6caf24ea32276c6664cb86db817e03a94c60afa0eaf"},
 ]
 certifi = [
-    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
-    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+    {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
+    {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
 ]
 cffi = [
     {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
@@ -1704,8 +1689,8 @@ gitpython = [
     {file = "GitPython-3.1.27.tar.gz", hash = "sha256:1c885ce809e8ba2d88a29befeb385fcea06338d3640712b59ca623c220bb5704"},
 ]
 identify = [
-    {file = "identify-2.5.0-py2.py3-none-any.whl", hash = "sha256:3acfe15a96e4272b4ec5662ee3e231ceba976ef63fd9980ed2ce9cc415df393f"},
-    {file = "identify-2.5.0.tar.gz", hash = "sha256:c83af514ea50bf2be2c4a3f2fb349442b59dc87284558ae9ff54191bff3541d2"},
+    {file = "identify-2.5.1-py2.py3-none-any.whl", hash = "sha256:0dca2ea3e4381c435ef9c33ba100a78a9b40c0bab11189c7cf121f75815efeaa"},
+    {file = "identify-2.5.1.tar.gz", hash = "sha256:3d11b16f3fe19f52039fb7e39c9c884b21cb1b586988114fbe42671f03de3e82"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1942,43 +1927,6 @@ pycodestyle = [
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
-]
-pydantic = [
-    {file = "pydantic-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cb23bcc093697cdea2708baae4f9ba0e972960a835af22560f6ae4e7e47d33f5"},
-    {file = "pydantic-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1d5278bd9f0eee04a44c712982343103bba63507480bfd2fc2790fa70cd64cf4"},
-    {file = "pydantic-1.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab624700dc145aa809e6f3ec93fb8e7d0f99d9023b713f6a953637429b437d37"},
-    {file = "pydantic-1.9.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c8d7da6f1c1049eefb718d43d99ad73100c958a5367d30b9321b092771e96c25"},
-    {file = "pydantic-1.9.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3c3b035103bd4e2e4a28da9da7ef2fa47b00ee4a9cf4f1a735214c1bcd05e0f6"},
-    {file = "pydantic-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3011b975c973819883842c5ab925a4e4298dffccf7782c55ec3580ed17dc464c"},
-    {file = "pydantic-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:086254884d10d3ba16da0588604ffdc5aab3f7f09557b998373e885c690dd398"},
-    {file = "pydantic-1.9.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0fe476769acaa7fcddd17cadd172b156b53546ec3614a4d880e5d29ea5fbce65"},
-    {file = "pydantic-1.9.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8e9dcf1ac499679aceedac7e7ca6d8641f0193c591a2d090282aaf8e9445a46"},
-    {file = "pydantic-1.9.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1e4c28f30e767fd07f2ddc6f74f41f034d1dd6bc526cd59e63a82fe8bb9ef4c"},
-    {file = "pydantic-1.9.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:c86229333cabaaa8c51cf971496f10318c4734cf7b641f08af0a6fbf17ca3054"},
-    {file = "pydantic-1.9.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:c0727bda6e38144d464daec31dff936a82917f431d9c39c39c60a26567eae3ed"},
-    {file = "pydantic-1.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:dee5ef83a76ac31ab0c78c10bd7d5437bfdb6358c95b91f1ba7ff7b76f9996a1"},
-    {file = "pydantic-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9c9bdb3af48e242838f9f6e6127de9be7063aad17b32215ccc36a09c5cf1070"},
-    {file = "pydantic-1.9.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ee7e3209db1e468341ef41fe263eb655f67f5c5a76c924044314e139a1103a2"},
-    {file = "pydantic-1.9.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b6037175234850ffd094ca77bf60fb54b08b5b22bc85865331dd3bda7a02fa1"},
-    {file = "pydantic-1.9.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b2571db88c636d862b35090ccf92bf24004393f85c8870a37f42d9f23d13e032"},
-    {file = "pydantic-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8b5ac0f1c83d31b324e57a273da59197c83d1bb18171e512908fe5dc7278a1d6"},
-    {file = "pydantic-1.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:bbbc94d0c94dd80b3340fc4f04fd4d701f4b038ebad72c39693c794fd3bc2d9d"},
-    {file = "pydantic-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e0896200b6a40197405af18828da49f067c2fa1f821491bc8f5bde241ef3f7d7"},
-    {file = "pydantic-1.9.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7bdfdadb5994b44bd5579cfa7c9b0e1b0e540c952d56f627eb227851cda9db77"},
-    {file = "pydantic-1.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:574936363cd4b9eed8acdd6b80d0143162f2eb654d96cb3a8ee91d3e64bf4cf9"},
-    {file = "pydantic-1.9.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c556695b699f648c58373b542534308922c46a1cda06ea47bc9ca45ef5b39ae6"},
-    {file = "pydantic-1.9.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:f947352c3434e8b937e3aa8f96f47bdfe6d92779e44bb3f41e4c213ba6a32145"},
-    {file = "pydantic-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5e48ef4a8b8c066c4a31409d91d7ca372a774d0212da2787c0d32f8045b1e034"},
-    {file = "pydantic-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:96f240bce182ca7fe045c76bcebfa0b0534a1bf402ed05914a6f1dadff91877f"},
-    {file = "pydantic-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:815ddebb2792efd4bba5488bc8fde09c29e8ca3227d27cf1c6990fc830fd292b"},
-    {file = "pydantic-1.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6c5b77947b9e85a54848343928b597b4f74fc364b70926b3c4441ff52620640c"},
-    {file = "pydantic-1.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c68c3bc88dbda2a6805e9a142ce84782d3930f8fdd9655430d8576315ad97ce"},
-    {file = "pydantic-1.9.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a79330f8571faf71bf93667d3ee054609816f10a259a109a0738dac983b23c3"},
-    {file = "pydantic-1.9.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f5a64b64ddf4c99fe201ac2724daada8595ada0d102ab96d019c1555c2d6441d"},
-    {file = "pydantic-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a733965f1a2b4090a5238d40d983dcd78f3ecea221c7af1497b845a9709c1721"},
-    {file = "pydantic-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cc6a4cb8a118ffec2ca5fcb47afbacb4f16d0ab8b7350ddea5e8ef7bcc53a16"},
-    {file = "pydantic-1.9.0-py3-none-any.whl", hash = "sha256:085ca1de245782e9b46cefcf99deecc67d418737a1fd3f6a4f511344b613a5b3"},
-    {file = "pydantic-1.9.0.tar.gz", hash = "sha256:742645059757a56ecd886faf4ed2441b9c0cd406079c2b4bee51bcc3fbcd510a"},
 ]
 pydocstyle = [
     {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ aiohttp = {extras = ["speedups"], version = "^3.8.1"}
 geojson = "^2.5.0"
 faker = "^13.11.1"
 click-log = "^0.4.0"
-pydantic = "^1.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ aiohttp = {extras = ["speedups"], version = "^3.8.1"}
 geojson = "^2.5.0"
 faker = "^13.11.1"
 click-log = "^0.4.0"
+pydantic = "^1.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/src/stac_api_benchmark/__main__.py
+++ b/src/stac_api_benchmark/__main__.py
@@ -1,7 +1,8 @@
 """Command-line interface."""
 import asyncio
 import logging
-from typing import Optional, Any
+from typing import Any
+from typing import Optional
 
 import click
 import click_log

--- a/src/stac_api_benchmark/__main__.py
+++ b/src/stac_api_benchmark/__main__.py
@@ -52,7 +52,7 @@ click_log.basic_config(logger)
 @click.command()
 @click.version_option()
 @click.option("--url", required=True, help="The root / Landing Page url for a STAC API")
-@click.option("--collection", required=True, help="The collection to operate on")
+@click.option("--collection", required=True, help="The collection over which to query")
 @click.option(
     "--concurrency", default=10, help="The number of concurrent request to run"
 )
@@ -81,12 +81,12 @@ click_log.basic_config(logger)
 @click.option(
     "--num-random",
     default=10000,
-    help="Only query this number of features from the feature collection inputs",
+    help="The number of random queries to run",
 )
 @click.option(
     "--max-items",
     default=10000,
-    help="Request this maximum number of items from the API for each query.",
+    help="Request this maximum number of items from the API for each query",
 )
 @click_log.simple_verbosity_option(logger)
 def main(

--- a/src/stac_api_benchmark/__main__.py
+++ b/src/stac_api_benchmark/__main__.py
@@ -9,10 +9,44 @@ import click_log
 
 from . import query
 
+# these IDs have self-intersections, so can't be used to query some databases (e.g., ES)
+TNC_EXCLUDED_IDS = [
+    "10026",
+    "10096",
+    "10100",
+    "10123",
+    "10158",
+    "10201",
+    "10266",
+    "10213",
+    "10289",
+    "10321",
+    "10339",
+    "10342",
+    "10354",
+    "10356",
+    "17105",
+    "10378",
+    "10385",
+    "10425",
+    "10598",
+    "10633",
+    "10691",
+    "10700",
+    "17009",
+    "10015",
+    "10032",
+    "10040",
+    "10042",
+    "10046",
+    "10047",
+    "10050",
+    "10051",
+    "10076",
+]
+
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
-
-DEFAULT_RANDOM_QUERIES = 1000
 
 
 @click.command()
@@ -39,9 +73,14 @@ DEFAULT_RANDOM_QUERIES = 1000
     help="Name of third queryable, ranged 0-100",
 )
 @click.option(
-    "--features",
+    "--num-features",
     default=None,
     type=int,
+    help="Only query this number of features from the feature collection inputs",
+)
+@click.option(
+    "--num-random",
+    default=10000,
     help="Only query this number of features from the feature collection inputs",
 )
 @click.option(
@@ -58,140 +97,71 @@ def main(
     first_queryable: str,
     second_queryable: str,
     third_queryable: str,
-    features: Optional[int],
+    num_features: Optional[int],
+    num_random: int,
     max_items: int,
 ) -> None:
     """STAC API Benchmark."""
     asyncio.run(
         run(
-            url=url,
-            collection=collection,
-            concurrency=concurrency,
-            seed=seed,
-            first_queryable=first_queryable,
-            second_queryable=second_queryable,
-            third_queryable=third_queryable,
-            num_features=features,
-            max_items=max_items,
+            query.BenchmarkConfig(
+                url=url,
+                collection=collection,
+                concurrency=concurrency,
+                seed=seed,
+                first_queryable=first_queryable,
+                second_queryable=second_queryable,
+                third_queryable=third_queryable,
+                num_features=num_features,
+                num_random=num_random,
+                max_items=max_items,
+                logger=logger,
+            )
         )
     )
 
 
-async def run(
-    url: str,
-    collection: str,
-    concurrency: int,
-    seed: int,
-    first_queryable: str,
-    second_queryable: str,
-    third_queryable: str,
-    num_features: Optional[int],
-    max_items: int,
-) -> None:
+async def run(config: query.BenchmarkConfig) -> None:
     logger.info("Running STEP")
     result: Any = await query.search_with_fc(
-        url=url,
-        collection=collection,
+        config=config,
         fc_filename=query.STEP,
-        concurrency=concurrency,
         id_field="siteid",
-        logger=logger,
-        num_features=num_features,
-        max_items=max_items,
     )
     logger.info(f"STEP Results: total time: {result[1]:.2f}s")
 
     logger.info("Running TNC Ecoregions")
     result = await query.search_with_fc(
-        url=url,
-        collection=collection,
+        config=config,
         fc_filename=query.TNC_ECOREGIONS,
-        concurrency=concurrency,
         id_field="ECO_ID_U",
-        logger=logger,
-        num_features=num_features,
-        max_items=max_items,
-        # these IDs have self-intersections, so can't be
-        # used to query some databases (e.g., ES)
-        exclude_ids=[
-            "10026",
-            "10096",
-            "10100",
-            "10123",
-            "10158",
-            "10201",
-            "10266",
-            "10213",
-            "10289",
-            "10321",
-            "10339",
-            "10342",
-            "10354",
-            "10356",
-            "17105",
-            "10378",
-            "10385",
-            "10425",
-            "10598",
-            "10633",
-            "10691",
-            "10700",
-            "17009",
-            "10015",
-            "10032",
-            "10040",
-            "10042",
-            "10046",
-            "10047",
-            "10050",
-            "10051",
-            "10076",
-        ],
+        exclude_ids=TNC_EXCLUDED_IDS,
     )
     logger.info(f"TNC Ecoregions: {result[1]:.2f}s")
 
     logger.info("Running country political boundaries, in April 2019")
     result = await query.search_with_fc(
-        url=url,
-        collection=collection,
+        config=config,
         fc_filename=query.COUNTRIES,
-        concurrency=concurrency,
         id_field="name",
         datetime="2019-04-01T00:00:00Z/2019-05-01T00:00:00Z",
-        logger=logger,
-        num_features=num_features,
-        max_items=max_items,
     )
     logger.info(f"Countries: {result[1]:.2f}s")
 
     logger.info("Running country political boundaries, cloud cover ascending")
     result = await query.search_with_fc(
-        url=url,
-        collection=collection,
+        config=config,
         fc_filename=query.COUNTRIES,
-        concurrency=concurrency,
         id_field="name",
         sortby=[query.sortby("properties.eo:cloud_cover", "asc")],  # noqa
-        logger=logger,
-        num_features=num_features,
-        max_items=max_items,
     )
     logger.info(f"Countries: {result[1]:.2f}s")
 
-    logger.info(f"Running random queries (seeded with {seed})")
+    logger.info(f"Running random queries (seeded with {config.seed})")
     result = await query.search_with_random_queries(
-        url=url,
-        collection=collection,
-        concurrency=concurrency,
-        seed=seed,
-        first_queryable=first_queryable,
-        second_queryable=second_queryable,
-        third_queryable=third_queryable,
-        logger=logger,
-        num_searches=num_features or DEFAULT_RANDOM_QUERIES,
-        max_items=max_items,
+        config=config,
     )
-    logger.info(f"Random Queries (seeded with {seed}): {result[1]:.2f}s")
+    logger.info(f"Random Queries (seeded with {config.seed}): {result[1]:.2f}s")
 
     repeated_item_times = 10000
     repeated_item_concurrency = 50
@@ -200,78 +170,29 @@ async def run(
         f"concurrency={repeated_item_concurrency}"
     )
     result = await query.request_item_repeatedly(
-        url=url,
-        collection=collection,
+        config=config,
         times=repeated_item_times,
         concurrency=repeated_item_concurrency,
     )
     logger.info(f"Repeated: {result:.2f}s")
 
-    logger.info("Running sort -properties.eo:cloud_cover")
-    result = await query.sorting(
-        url=url,
-        collection=collection,
-        concurrency=50,
-        sortby=[query.sortby("properties.eo:cloud_cover", "desc")],  # noqa
-        logger=logger,
-        max_items=max_items,
-    )
-    logger.info(f"sort -properties.eo:cloud_cover : {result[1]:.2f}s")
+    await run_sort(config, "properties.eo:cloud_cover", "desc")
+    await run_sort(config, "properties.eo:cloud_cover", "asc")
 
-    logger.info("Running sort +properties.eo:cloud_cover")
-    result = await query.sorting(
-        url,
-        collection,
-        concurrency=50,
-        sortby=[query.sortby("properties.eo:cloud_cover", "asc")],  # noqa
-        logger=logger,
-        max_items=max_items,
-    )
-    logger.info(f"sort +properties.eo:cloud_cover : {result[1]:.2f}s")
+    await run_sort(config, "properties.datetime", "desc")
+    await run_sort(config, "properties.datetime", "asc")
 
-    logger.info("Running sort -properties.datetime")
-    result = await query.sorting(
-        url,
-        collection,
-        concurrency=50,
-        sortby=[query.sortby("properties.datetime", "desc")],  # noqa
-        logger=logger,
-        max_items=max_items,
-    )
-    logger.info(f"sort -properties.datetime : {result[1]:.2f}s")
+    await run_sort(config, "properties.created", "desc")
+    await run_sort(config, "properties.created", "asc")
 
-    logger.info("Running sort +properties.datetime")
-    result = await query.sorting(
-        url,
-        collection,
-        concurrency=50,
-        sortby=[query.sortby("properties.datetime", "asc")],  # noqa
-        logger=logger,
-        max_items=max_items,
-    )
-    logger.info(f"sort +properties.datetime : {result[1]:.2f}s")
 
-    logger.info("Running sort -properties.created")
+async def run_sort(config: query.BenchmarkConfig, field: str, direction: str) -> None:
+    logger.info(f"Running sort {field} {direction}")
     result = await query.sorting(
-        url,
-        collection,
-        concurrency=50,
-        sortby=[query.sortby("properties.created", "desc")],  # noqa
-        logger=logger,
-        max_items=max_items,
+        config,
+        sortby=[query.sortby(field, direction)],  # noqa
     )
-    logger.info(f"sort -properties.created : {result[1]:.2f}s")
-
-    logger.info("Running sort +properties.created")
-    result = await query.sorting(
-        url,
-        collection,
-        concurrency=50,
-        sortby=[query.sortby("properties.created", "asc")],  # noqa
-        logger=logger,
-        max_items=max_items,
-    )
-    logger.info(f"sort +properties.created : {result[1]:.2f}s")
+    logger.info(f"Results: sort {field} {direction} : {result[1]:.2f}s")
 
 
 if __name__ == "__main__":

--- a/src/stac_api_benchmark/query.py
+++ b/src/stac_api_benchmark/query.py
@@ -4,6 +4,7 @@ import importlib.resources
 import json
 import traceback
 from asyncio import Semaphore
+from dataclasses import dataclass
 from datetime import timezone as tz
 from logging import Logger
 from time import perf_counter
@@ -17,7 +18,6 @@ from zipfile import ZipFile
 
 import aiohttp
 from faker import Faker
-from pydantic import BaseModel
 from pystac import Item
 from pystac_client import Client
 from pystac_client.exceptions import APIError
@@ -29,7 +29,8 @@ TNC_ECOREGIONS = "tnc_terr_ecoregions.geojson.zip"
 COUNTRIES = "countries.geojson"
 
 
-class BenchmarkConfig(BaseModel):  # type: ignore
+@dataclass
+class BenchmarkConfig:
     """Config."""
 
     url: str


### PR DESCRIPTION
Add `--timeout` parameter to explicitly timeout the requests. This allows better apples-to-apples comparisons between APIs that have an explicit timeout for requests and those that don't. 

For example, you can run the benchmark without a timeout and get one set of results where one API fails a lot and the other succeeds but may have very long response times, and another with an explicit timeout to comare only which request succeeded in under the timeout.